### PR TITLE
Sync sequence numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+  - "6"
+  - "node"
+sudo: false

--- a/index.js
+++ b/index.js
@@ -14,6 +14,12 @@ var Logs = function (db, opts) {
   this.sep = opts.separator || opts.sep || '!'
   this.prefix = opts.prefix ? this.sep + opts.prefix + this.sep : ''
   this.valueEncoding = opts.valueEncoding
+
+  // Global lock used to ensure sequential numbering.
+  this.locked = false
+  // FIFO of write operations waiting for the global lock.
+  // [[method, args...], [method, args...], ...]
+  this.pending = []
 }
 
 Logs.prototype.key = function (log, seq) {
@@ -41,21 +47,70 @@ Logs.prototype.get = function (log, seq, cb) {
   this.db.get(this.key(log, seq), {valueEncoding: this.valueEncoding}, cb)
 }
 
-Logs.prototype.put = function (log, seq, value, cb) {
-  this.db.put(this.key(log, seq), value, {valueEncoding: this.valueEncoding}, cb)
-}
-
-Logs.prototype.append = function (log, value, cb) {
-  if (!cb) cb = noop
+Logs.prototype.put = function put (log, seq, value, cb) {
   var self = this
 
-  this.head(log, function (err, seq) {
-    if (err) return cb(err)
-    self.put(log, seq + 1, value, function (err) {
-      if (err) return cb(err)
-      cb(null, seq + 1)
+  // If the current head of log "x" is 55 and we put("x", 99, value),
+  // the put will advance the head of "x" to 99. Since puts can advance
+  // the head of a log, we need the global lock for puts, too.
+  if (self.locked) return this.pending.push([put, log, seq, value, cb])
+  self.locked = true
+  var opts = {valueEncoding: self.valueEncoding}
+  self.db.put(self.key(log, seq), value, opts, function (err) {
+    doPending.call(self)
+    cb(err)
+  })
+}
+
+Logs.prototype.append = function append (log, value, cb) {
+  var self = this
+
+  if (!cb) cb = noop
+  // Because head() is async, sync calls like
+  //
+  //     logs.append("x", "a")
+  //     logs.append("x", "b")
+  //
+  // may calculate the same head value and try to write to the same key.
+  // As a result, the second append call will overwrite "a" with "b" at
+  // new head.
+  //
+  // To prevent this, every write to the underlying LevelUP takes out
+  // a global lock. While locked, all other put and append calls get
+  // queued for execution when the lock becomes available again.
+  //
+  // The problem does't affect nested async appends like:
+  //
+  //     logs.append("x", "a", function () {
+  //         logs.append("x", "b", function () {
+  //             ...
+  //         })
+  //     })
+  //
+  if (self.locked) return this.pending.push([append, log, value, cb])
+  self.locked = true
+  self.head(log, function (err, head) {
+    if (err) {
+      doPending.call(self)
+      return cb(err)
+    }
+    var seq = head + 1
+    var key = self.key(log, seq)
+    var opts = {valueEncoding: self.valueEncoding}
+    self.db.put(key, value, opts, function (err) {
+      doPending.call(self)
+      cb(err, seq)
     })
   })
+}
+
+// Unlock and execute the next waiting write operation.
+function doPending () {
+  this.locked = false
+  if (this.pending.length !== 0) {
+    var next = this.pending.shift()
+    next[0].apply(this, next.slice(1))
+  }
 }
 
 Logs.prototype.head = function (log, cb) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "memdb": "^0.2.0",
-    "standard": "^2.3.1",
+    "standard": "^7.1.2",
     "tape": "^3.5.0"
   },
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -50,3 +50,36 @@ tape('append sequence numbers', function (t) {
     if (returned === 2) t.end()
   }
 })
+
+tape('put then append', function (t) {
+  var lgs = logs(memdb(), {valueEncoding: 'json'})
+  var returned = 0
+
+  lgs.put('mathias', 1, {hello: 'world'}, function (err) {
+    t.ifError(err, 'no error')
+    returned++
+    done()
+  })
+  lgs.append('mathias', {hej: 'verden'}, function (err, seq) {
+    t.ifError(err, 'no error')
+    t.equal(seq, 2, 'appended entry gets seq 2')
+    returned++
+    done()
+  })
+  function done () {
+    if (returned === 2) t.end()
+  }
+})
+
+tape('put advances head', function (t) {
+  var lgs = logs(memdb(), {valueEncoding: 'json'})
+
+  lgs.put('mathias', 5, {hello: 'world'}, function (err) {
+    t.ifError(err, 'no error')
+    lgs.append('mathias', {hej: 'verden'}, function (err, seq) {
+      t.ifError(err, 'no error')
+      t.equal(seq, 6, 'appended entry gets seq 6')
+      t.end()
+    })
+  })
+})

--- a/test.js
+++ b/test.js
@@ -30,6 +30,41 @@ tape('can add', function (t) {
   })
 })
 
+tape('three appends', function (t) {
+  var lgs = logs(memdb(), {valueEncoding: 'json'})
+
+  lgs.append('mathias', {hello: 'world'}, function () {
+    lgs.append('mathias', {hej: 'verden'}, function () {
+      lgs.append('mathias', {privet: 'mir'}, function () {
+        collect(lgs.createReadStream('mathias'), function (err, datas) {
+          if (err) throw err
+
+          t.same(datas, [{
+            log: 'mathias',
+            seq: 1,
+            value: {
+              hello: 'world'
+            }
+          }, {
+            log: 'mathias',
+            seq: 2,
+            value: {
+              hej: 'verden'
+            }
+          }, {
+            log: 'mathias',
+            seq: 3,
+            value: {
+              privet: 'mir'
+            }
+          }], 'saved logs')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 tape('append sequence numbers', function (t) {
   var lgs = logs(memdb(), {valueEncoding: 'json'})
   var returned = 0

--- a/test.js
+++ b/test.js
@@ -29,3 +29,24 @@ tape('can add', function (t) {
     })
   })
 })
+
+tape('append sequence numbers', function (t) {
+  var lgs = logs(memdb(), {valueEncoding: 'json'})
+  var returned = 0
+
+  lgs.append('mathias', {hello: 'world'}, function (err, seq) {
+    t.ifError(err, 'no error')
+    t.equal(seq, 1, 'first gets seq 1')
+    returned++
+    done()
+  })
+  lgs.append('mathias', {hej: 'verden'}, function (err, seq) {
+    t.ifError(err, 'no error')
+    t.equal(seq, 2, 'second gets seq 2')
+    returned++
+    done()
+  })
+  function done () {
+    if (returned === 2) t.end()
+  }
+})


### PR DESCRIPTION
This PR:
1. Updates test tools and configuration so things are green and happy again.
2. Fixes an issue where sync calls to `logs.append(...)` yielded bad `seq` numbers and dropped data.

The problem case looked something like:

``` js
logs.append("test", "a", function(error, seq) {
    console.log(seq)
})
// more sync stuff
logs.append("test", "b", function(error, seq) {
    console.log(seq)
})
```

Since `append` calls `head` to calculate the current head sequence number, both sync calls to `append` would find the same head, add one to it, write to the same key, last-write-wins, and yield the same `seq` to their callbacks. Not good.

The solution in this PR is a global write lock and a FIFO for write operations (`append` and `put`) waiting for the lock. I've also added tests.

Usually a global lock would make me kind of queasy, but since LevelDOWN especially is single-process-only to begin with, I don't see much harm in it. I suppose there's an extreme argument for something like stream semantics, but this simpler approach ought to catch most potentially surprising use cases.

This is one of a few of your packages I've played with recently. I know you wouldn't do it any other way, but all the same: Thanks for sharing your work!
